### PR TITLE
turn off float32 conversion

### DIFF
--- a/introductory/experiments/datasets/laion_5b/loader.py
+++ b/introductory/experiments/datasets/laion_5b/loader.py
@@ -88,7 +88,8 @@ def load_embedding(shard_number: int, params: DownloadParams):
     embedding_arr = np.load(embedding_path)
     # The laion-5B dataset uses float16 for embeddings.  Parquet does not support this and
     # so we convert to float32
-    embedding_arr = embedding_arr.astype(np.single)
+    # Can comment this out if using PyArrow 15.0.0 (or nightly right as of this comment)
+    # embedding_arr = embedding_arr.astype(np.single)
     width = embedding_arr.shape[1]
     embedding_arr.shape = -1
     return pa.FixedSizeListArray.from_arrays(embedding_arr, width)


### PR DESCRIPTION
We can keep as float16 as long as we use new versions of PyArrow. Right now we have to download the pre-release from PyPI. (I wasn't able to get the Conda pre-release working, but I made an upstream issue: apache/arrow#39434.)